### PR TITLE
User last connection

### DIFF
--- a/api/Repositories/user_repository.py
+++ b/api/Repositories/user_repository.py
@@ -1,11 +1,13 @@
 from api.models.user import User
 from api.Repositories.db import DataBase
+from datetime import datetime
 
 
 class UserRepository():
 
     @staticmethod
     def add_user(user):
+        user.last_connection = datetime.now().date()
         return user.save()
 
     @staticmethod
@@ -25,6 +27,12 @@ class UserRepository():
     @staticmethod
     def update_expo_token(token,email):
         User.objects(email=email).update(expo_token=token)
+        return UserRepository.get_user_by_email(email)
+
+    @staticmethod
+    def update_last_connection(last_connection, email):
+        datetime_object = datetime.strptime(last_connection, '%Y-%m-%d')
+        User.objects(email=email).update(last_connection=datetime_object)
         return UserRepository.get_user_by_email(email)
 
     @staticmethod

--- a/api/controllers/user_controller.py
+++ b/api/controllers/user_controller.py
@@ -44,10 +44,18 @@ class UserController:
     def post_sessions(user):
         result =  UserController.find_by_email(user.email)
         if result["users"]:
-            UserRepository.update_last_connection(user.last_connection, user.email)
+            UserRepository.update_last_connection(user.email)
             if result["users"][0]["expo_token"] != user.expo_token:
                 UserController.update_expo_token(user.expo_token,user.email)
         else:
             UserController.create(user)
         return {"message": "session created"}
 
+    @staticmethod
+    def get_users_with_last_connection(frm, to):
+        result = UserRepository.get_users_with_last_connection(frm, to)
+        result = map(lambda user: user.convert_to_json(), list(result))
+        result_list = list(result)
+        if len(result_list) == 0:
+            return {"users": []}
+        return {"users": result_list}

--- a/api/controllers/user_controller.py
+++ b/api/controllers/user_controller.py
@@ -44,6 +44,7 @@ class UserController:
     def post_sessions(user):
         result =  UserController.find_by_email(user.email)
         if result["users"]:
+            UserRepository.update_last_connection(user.last_connection, user.email)
             if result["users"][0]["expo_token"] != user.expo_token:
                 UserController.update_expo_token(user.expo_token,user.email)
         else:

--- a/api/models/requests/user.py
+++ b/api/models/requests/user.py
@@ -5,3 +5,9 @@ class User(BaseModel):
     name: str
     email: str
     expo_token: str
+    last_connection: str
+
+class CreateUser(BaseModel):
+    name: str
+    email: str
+    expo_token: str

--- a/api/models/requests/user.py
+++ b/api/models/requests/user.py
@@ -5,9 +5,3 @@ class User(BaseModel):
     name: str
     email: str
     expo_token: str
-    last_connection: str
-
-class CreateUser(BaseModel):
-    name: str
-    email: str
-    expo_token: str

--- a/api/models/user.py
+++ b/api/models/user.py
@@ -6,9 +6,11 @@ class User(Document):
     name = mongoengine.StringField()
     email = mongoengine.StringField()
     expo_token = mongoengine.StringField(null=True)
+    last_connection = mongoengine.DateTimeField()
 
     def convert_to_json(self):
         result = self.to_mongo().to_dict()
+        result["last_connection"] = result["last_connection"].strftime('%Y-%m-%d')
         if "_id" in result:
             del result["_id"]
         return result

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from api.models.requests.user import User
+from api.models.requests.user import User, CreateUser
 from api.controllers.user_controller import UserController
 from api.models.responses.message import Message
 from api.models.responses.user import User as UserResponse
@@ -12,7 +12,7 @@ router = APIRouter(tags=["Users"])
 
 
 @router.post("/users", response_model=UserResponse)
-async def create_user(user: User):
+async def create_user(user: CreateUser):
     return UserController.create(user)
 
 

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from api.models.requests.user import User, CreateUser
+from api.models.requests.user import User
 from api.controllers.user_controller import UserController
 from api.models.responses.message import Message
 from api.models.responses.user import User as UserResponse
@@ -12,9 +12,8 @@ router = APIRouter(tags=["Users"])
 
 
 @router.post("/users", response_model=UserResponse)
-async def create_user(user: CreateUser):
+async def create_user(user: User):
     return UserController.create(user)
-
 
 @router.get("/users",response_model=UsersResponse)
 async def find_user(email: str = ""):
@@ -31,3 +30,7 @@ async def delete_users(email: str = ""):
 @router.post("/users/sessions", status_code=201, response_model=Message)
 async def post_sesions(user: User):
     return UserController.post_sessions(user)
+
+@router.get("/users/lastConnection")
+async def get_users_with_last_connection(frm: int = 0, to: int = 0):
+    return UserController.get_users_with_last_connection(frm, to)

--- a/tests/controllers/test_user_controller.py
+++ b/tests/controllers/test_user_controller.py
@@ -2,7 +2,7 @@ import pytest
 
 from api.controllers.user_controller import UserController
 from api.models.requests.token import Token
-from api.models.requests.user import User, CreateUser
+from api.models.requests.user import User
 from fastapi import HTTPException
 from datetime import datetime
 
@@ -12,7 +12,7 @@ def test_create_user_with_all_parameters(init):
     email = "mockname@email.com"
     expo_token = "123"
     last_connection = datetime.now().date()
-    user = CreateUser(name=name,email=email,expo_token=expo_token)
+    user = User(name=name,email=email,expo_token=expo_token)
     response = UserController.create(user)
     assert response == {
         "user": {
@@ -28,7 +28,7 @@ def test_create_user_without_expo_token(init):
     email = "mockname@email.com"
     expo_token = ""
     last_connection = datetime.now().date()
-    user = CreateUser(name=name,email=email,expo_token=expo_token)
+    user = User(name=name,email=email,expo_token=expo_token)
     response = UserController.create(user)
     assert response == {
         "user": {
@@ -44,7 +44,7 @@ def test_delete_user_by_email(init):
     email = "mockname@email.com"
     expo_token = "123"
     last_connection = datetime.now().date().strftime('%Y-%m-%d')
-    user = User(name=name,email=email,expo_token=expo_token, last_connection=last_connection)
+    user = User(name=name,email=email,expo_token=expo_token)
     UserController.create(user)
     delete_response = UserController.delete_users(email)
     get_response = UserController.find_by_email("")
@@ -56,12 +56,12 @@ def test_delete_all_users(init):
     email = "mockname@email.com"
     expo_token = "123"
     last_connection = datetime.now().date().strftime('%Y-%m-%d')
-    user = User(name=name,email=email,expo_token=expo_token, last_connection=last_connection)
+    user = User(name=name,email=email,expo_token=expo_token)
     UserController.create(user)
     name = "mockname2"
     email = "mockname@email.com2"
     expo_token = "1234"
-    user = User(name=name,email=email,expo_token=expo_token, last_connection=last_connection)
+    user = User(name=name,email=email,expo_token=expo_token)
     UserController.create(user)
     delete_response = UserController.delete_users("")
     get_response = UserController.find_by_email("")
@@ -73,7 +73,7 @@ def test_find_user_by_email(init):
     email = "mockname@email.com"
     expo_token = "123"
     last_connection = datetime.now().date().strftime('%Y-%m-%d')
-    user = User(name=name,email=email,expo_token=expo_token,last_connection=last_connection)
+    user = User(name=name,email=email,expo_token=expo_token)
     UserController.create(user)
     response = UserController.find_by_email(email)
     assert response == {
@@ -92,11 +92,11 @@ def test_find_all_users(init):
     email = "mockname@email.com"
     expo_token = "123"
     last_connection = datetime.now().date().strftime('%Y-%m-%d')
-    UserController.create(User(name=name,email=email,expo_token=expo_token,last_connection=last_connection))
+    UserController.create(User(name=name,email=email,expo_token=expo_token))
     name2 = "mockname2"
     email2 = "mockname2@email.com"
     expo_token2 = "1234"
-    UserController.create(User(name=name2,email=email2,expo_token=expo_token2,last_connection=last_connection))
+    UserController.create(User(name=name2,email=email2,expo_token=expo_token2))
     response = UserController.find_by_email("")
     assert len(response["users"]) == 2
     assert response == {
@@ -122,7 +122,7 @@ def test_update_token(init):
     email = "mockname@email.com"
     empty_expo_token = ""
     last_connection = datetime.now().date().strftime('%Y-%m-%d')
-    user = User(name=name,email=email,expo_token =empty_expo_token,last_connection=last_connection)
+    user = User(name=name,email=email,expo_token =empty_expo_token)
     response = UserController.create(user)
     assert response == {
         "user": {
@@ -148,7 +148,7 @@ def test_post_sessions_existing_user_diferent_token(init):
     email = "mockname@email.com"
     expo_token = "123"
     last_connection = datetime.now().date().strftime('%Y-%m-%d')
-    user = User(name=name,email=email,expo_token =expo_token,last_connection=last_connection)
+    user = User(name=name,email=email,expo_token =expo_token)
     response = UserController.create(user)
     assert response == {
         "user": {
@@ -159,7 +159,7 @@ def test_post_sessions_existing_user_diferent_token(init):
         }
     }
     new_expo_token = "1234"
-    user_differen_token = User(name=name,email=email,expo_token =new_expo_token,last_connection=last_connection)
+    user_differen_token = User(name=name,email=email,expo_token =new_expo_token)
     response_sessions = UserController.post_sessions(user_differen_token)
     assert response_sessions == {"message": "session created"}
 
@@ -168,7 +168,7 @@ def test_post_sessions_existing_user_diferent_same_token(init):
     email = "mockname@email.com"
     expo_token = "123"
     last_connection = datetime.now().date().strftime('%Y-%m-%d')
-    user = User(name=name,email=email,expo_token =expo_token,last_connection=last_connection)
+    user = User(name=name,email=email,expo_token =expo_token)
     response = UserController.create(user)
     assert response == response == {
         "user": {
@@ -190,8 +190,7 @@ def test_post_sessions_non_existing_user_creates_user(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    last_connection = datetime.now().date().strftime('%Y-%m-%d')
-    user = User(name=name,email=email,expo_token =expo_token,last_connection=last_connection)
+    user = User(name=name,email=email,expo_token =expo_token)
     response = UserController.post_sessions(user)
     assert response == {
         "message": "session created"
@@ -204,22 +203,45 @@ def test_post_sessions_to_change_last_connection(init):
     name = "mockname"
     email = "mockname@email.com"
     empty_expo_token = ""
-    last_connection = datetime.now().date().strftime('%Y-%m-%d')
-    user = User(name=name, email=email, expo_token=empty_expo_token, last_connection=last_connection)
+    user = User(name=name, email=email, expo_token=empty_expo_token)
     response = UserController.create(user)
     assert response == {
         "user": {
             "name": name,
             "email": email,
             "expo_token": None,
-            "last_connection": last_connection
+            "last_connection": datetime.now().date().strftime('%Y-%m-%d')
         }
     }
-    last_connection = "2021-12-03"
-    user = User(name=name, email=email, expo_token=empty_expo_token, last_connection=last_connection)
+    user = User(name=name, email=email, expo_token=empty_expo_token)
     response_update = UserController.post_sessions(user)
     assert response_update == {
         "message": "session created"
     }
     response_all_users = UserController.find_by_email("")
-    assert response_all_users["users"][0]["last_connection"] == last_connection
+    assert response_all_users["users"][0]["last_connection"] == datetime.now().date().strftime('%Y-%m-%d')
+
+def test_get_users_with_last_connection(init):
+    name = "mockname"
+    email = "mockname@email.com"
+    expo_token = "ExpoToken"
+    user = User(name=name, email=email, expo_token=expo_token)
+    response = UserController.create(user)
+    assert response == {
+        "user": {
+            "name": name,
+            "email": email,
+            "expo_token": expo_token,
+            "last_connection": datetime.now().date().strftime('%Y-%m-%d')
+        }
+    }
+    users = UserController.get_users_with_last_connection(5,0)
+    assert users == {
+        "users": [
+        {
+            "name": "mockname",
+            "email": "mockname@email.com",
+            "expo_token": "ExpoToken",
+            "last_connection": datetime.now().date().strftime('%Y-%m-%d')
+        }
+    ]}

--- a/tests/controllers/test_user_controller.py
+++ b/tests/controllers/test_user_controller.py
@@ -2,21 +2,24 @@ import pytest
 
 from api.controllers.user_controller import UserController
 from api.models.requests.token import Token
-from api.models.requests.user import User
+from api.models.requests.user import User, CreateUser
 from fastapi import HTTPException
+from datetime import datetime
 
 
 def test_create_user_with_all_parameters(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    user = User(name=name,email=email,expo_token=expo_token)
+    last_connection = datetime.now().date()
+    user = CreateUser(name=name,email=email,expo_token=expo_token)
     response = UserController.create(user)
     assert response == {
         "user": {
             "name": name,
             "email": email,
-            "expo_token": expo_token
+            "expo_token": expo_token,
+            "last_connection": last_connection.isoformat()
         }
     }
 
@@ -24,13 +27,15 @@ def test_create_user_without_expo_token(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = ""
-    user = User(name=name,email=email,expo_token=expo_token)
+    last_connection = datetime.now().date()
+    user = CreateUser(name=name,email=email,expo_token=expo_token)
     response = UserController.create(user)
     assert response == {
         "user": {
             "name": name,
             "email": email,
-            "expo_token": None
+            "expo_token": None,
+            "last_connection": last_connection.isoformat()
         }
     }
 
@@ -38,7 +43,8 @@ def test_delete_user_by_email(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    user = User(name=name,email=email,expo_token=expo_token)
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name,email=email,expo_token=expo_token, last_connection=last_connection)
     UserController.create(user)
     delete_response = UserController.delete_users(email)
     get_response = UserController.find_by_email("")
@@ -49,12 +55,13 @@ def test_delete_all_users(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    user = User(name=name,email=email,expo_token=expo_token)
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name,email=email,expo_token=expo_token, last_connection=last_connection)
     UserController.create(user)
     name = "mockname2"
     email = "mockname@email.com2"
     expo_token = "1234"
-    user = User(name=name,email=email,expo_token=expo_token)
+    user = User(name=name,email=email,expo_token=expo_token, last_connection=last_connection)
     UserController.create(user)
     delete_response = UserController.delete_users("")
     get_response = UserController.find_by_email("")
@@ -65,7 +72,8 @@ def test_find_user_by_email(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    user = User(name=name,email=email,expo_token=expo_token)
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name,email=email,expo_token=expo_token,last_connection=last_connection)
     UserController.create(user)
     response = UserController.find_by_email(email)
     assert response == {
@@ -73,7 +81,8 @@ def test_find_user_by_email(init):
             {
                 "name": name,
                 "email": email,
-                "expo_token": expo_token
+                "expo_token": expo_token,
+                "last_connection": last_connection
             }
         ]
     }
@@ -82,11 +91,12 @@ def test_find_all_users(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    UserController.create(User(name=name,email=email,expo_token=expo_token))
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    UserController.create(User(name=name,email=email,expo_token=expo_token,last_connection=last_connection))
     name2 = "mockname2"
     email2 = "mockname2@email.com"
     expo_token2 = "1234"
-    UserController.create(User(name=name2,email=email2,expo_token=expo_token2))
+    UserController.create(User(name=name2,email=email2,expo_token=expo_token2,last_connection=last_connection))
     response = UserController.find_by_email("")
     assert len(response["users"]) == 2
     assert response == {
@@ -94,12 +104,14 @@ def test_find_all_users(init):
             {
                 "name": name,
                 "email": email,
-                "expo_token": expo_token
+                "expo_token": expo_token,
+                "last_connection": last_connection
             },
             {
                 "name": name2,
                 "email": email2,
-                "expo_token": expo_token2
+                "expo_token": expo_token2,
+                "last_connection": last_connection
             }
         ]
     }
@@ -109,13 +121,15 @@ def test_update_token(init):
     name = "mockname"
     email = "mockname@email.com"
     empty_expo_token = ""
-    user = User(name=name,email=email,expo_token =empty_expo_token)
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name,email=email,expo_token =empty_expo_token,last_connection=last_connection)
     response = UserController.create(user)
     assert response == {
         "user": {
             "name": name,
             "email": email,
-            "expo_token": None
+            "expo_token": None,
+            "last_connection": last_connection
         }
     }
     expo_token = "123"
@@ -124,7 +138,8 @@ def test_update_token(init):
         "user": {
             "name": name,
             "email": email,
-            "expo_token": expo_token
+            "expo_token": expo_token,
+            "last_connection": last_connection
         }
     }
 
@@ -132,17 +147,19 @@ def test_post_sessions_existing_user_diferent_token(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    user = User(name=name,email=email,expo_token =expo_token)
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name,email=email,expo_token =expo_token,last_connection=last_connection)
     response = UserController.create(user)
     assert response == {
         "user": {
             "name": name,
             "email": email,
-            "expo_token": expo_token
+            "expo_token": expo_token,
+            "last_connection": last_connection
         }
     }
     new_expo_token = "1234"
-    user_differen_token = User(name=name,email=email,expo_token =new_expo_token)
+    user_differen_token = User(name=name,email=email,expo_token =new_expo_token,last_connection=last_connection)
     response_sessions = UserController.post_sessions(user_differen_token)
     assert response_sessions == {"message": "session created"}
 
@@ -150,13 +167,15 @@ def test_post_sessions_existing_user_diferent_same_token(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    user = User(name=name,email=email,expo_token =expo_token)
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name,email=email,expo_token =expo_token,last_connection=last_connection)
     response = UserController.create(user)
     assert response == response == {
         "user": {
             "name": name,
             "email": email,
-            "expo_token": expo_token
+            "expo_token": expo_token,
+            "last_connection": last_connection
         }
     }
     response_sessions = UserController.post_sessions(user)
@@ -171,7 +190,8 @@ def test_post_sessions_non_existing_user_creates_user(init):
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    user = User(name=name,email=email,expo_token =expo_token)
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name,email=email,expo_token =expo_token,last_connection=last_connection)
     response = UserController.post_sessions(user)
     assert response == {
         "message": "session created"
@@ -179,3 +199,27 @@ def test_post_sessions_non_existing_user_creates_user(init):
 
     response_all_users = UserController.find_by_email("")
     assert len(response_all_users["users"])== 1
+
+def test_post_sessions_to_change_last_connection(init):
+    name = "mockname"
+    email = "mockname@email.com"
+    empty_expo_token = ""
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name, email=email, expo_token=empty_expo_token, last_connection=last_connection)
+    response = UserController.create(user)
+    assert response == {
+        "user": {
+            "name": name,
+            "email": email,
+            "expo_token": None,
+            "last_connection": last_connection
+        }
+    }
+    last_connection = "2021-12-03"
+    user = User(name=name, email=email, expo_token=empty_expo_token, last_connection=last_connection)
+    response_update = UserController.post_sessions(user)
+    assert response_update == {
+        "message": "session created"
+    }
+    response_all_users = UserController.find_by_email("")
+    assert response_all_users["users"][0]["last_connection"] == last_connection

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,24 +1,29 @@
 from api.models.user import User
+from datetime import datetime
 
 
 def test_model_with_all_parameters_convert_to_json():
     name = "mockname"
     email = "mockname@email.com"
     expo_token = "123"
-    user = User(name=name,email=email,expo_token=expo_token)
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name,email=email,expo_token=expo_token,last_connection=last_connection)
     assert user.convert_to_json() == {
          "name": name,
          "email": email,
-         "expo_token": expo_token
+         "expo_token": expo_token,
+         "last_connection": last_connection
     }
 
 def test_model_without_expo_token_convert_to_json():
     name = "mockname"
     email = "mockname@email.com"
     expo_token = ""
-    user = User(name=name,email=email)
+    last_connection = datetime.now().date().strftime('%Y-%m-%d')
+    user = User(name=name,email=email,last_connection=last_connection)
     assert user.convert_to_json() == {
          "name": name,
          "email": email,
-         "expo_token": None
+         "expo_token": None,
+        "last_connection": last_connection
     }

--- a/tests/repositories/user_repository_test.py
+++ b/tests/repositories/user_repository_test.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from api.Repositories.user_repository import UserRepository
 from api.models.user import User
 
@@ -47,6 +49,15 @@ def test_get_all_users(init):
     assert result[1].email == email2
     assert result[1].expo_token == expo_token2
 
+def test_get_users_with_last_connection(init):
+    name = "mockname"
+    email = "mockname@email.com"
+    expo_token = "123"
+    UserRepository.add_user(User(name=name,email=email,expo_token=expo_token))
+    result = UserRepository.get_users_with_last_connection(5,0)
+    assert result.get().name == name
+    assert result.get().email == email
+    assert result.get().expo_token == expo_token
 
 def test_delete_all_users(init):
     UserRepository.delete_all_users()


### PR DESCRIPTION
### Descripcion

- Almacenar sesiones de usuarios

- Endpoint para consultar ultima sesión

### Criterios de aceptacion

CA1: Se almacenara en la base de datos, la ultima vez que se conecto un usuario en la aplicacion.
CA2: Si un usuario se registra, en la base de datos se guarda la ultima conexion como si fuese ese dia.
CA3: Un endpoint en el cual a partir de un cierto rango de dias desde hoy, por ejemplo (5,0) indica un rango de dias desde hoy hasta 5 dias atras, devuelva los usuarios con su ultima conexion perteneciente a ese rango.

### Issues asociados
https://lisa-tdp2.atlassian.net/jira/software/projects/IDIOMAPLAY/boards/2?selectedIssue=IDIOMAPLAY-59
